### PR TITLE
Fixing the battle.net link in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Note: You need proper privileges to invite a bot your server.
 If you want to download PugBot and host him yourself, you will need the following:
 
 + A Discord Bot Token ([Click Here](https://discordapp.com/developers/applications/]))
-+ A WoW API Key ([dev.battle.net](dev.battle.net))
++ A WoW API Key ([dev.battle.net](https://dev.battle.net))
 
 Add the token and api key to config.json and run pugbot.py
 


### PR DESCRIPTION
The link dev.battle.net currently redirects to https://github.com/reznok/PugBot/blob/master/dev.battle.net.